### PR TITLE
Githubでのログイン処理を追加

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,7 @@
+class SessionsController < ApplicationController
+  def create
+    user = User.find_or_create_from_auth_hash!(request.env["omniauth.auth"])
+    session[:user_id] = user.id
+    redirect_to root_path, notice: "ログインしました"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,13 @@
 class User < ApplicationRecord
+  def self.find_or_create_from_auth_hash!(auth_hash)
+    provider = auth_hash[:provider]
+    uid = auth_hash[:uid]
+    nickname = auth_hash[:info][:nickname]
+    image_url = auth_hash[:info][:image]
+
+    User.find_or_create_by!(provider: provider, uid: uid) do |user|
+      user.name = nickname
+      user.image_url = image_url
+    end
+  end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -15,4 +15,7 @@
           %li.nav-item
             = link_to "GitHubでログイン", "/auth/github", class: "nav-link", method: :post
     .container
+      - if flash.notice
+        .alert.alert-success
+          = flash.notice
       = yield

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   root 'welcome#index'
+  get "/auth/:provider/callback" => "sessions#create"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
## 変更前
- GitHubでのログイン後、omniauthがcallbackした先のコントローラがないため、エラーが発生する。
    - 対象のパス：`/auth/:provider/callback`

## 修正内容
- Sessionsコントローラを作成
    - > 原因：omniauthがcallbackした先のコントローラがなかったため。