### PR TITLE
イベントリソースを追加

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,2 @@
+class EventsController < ApplicationController
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,18 @@
+class Event < ApplicationRecord
+  validates :name, length: { maximum: 50 }, presence: true
+  validates :place, length: { maximum: 100 }, presence: true
+  validates :content, length: { maximum: 2000 }, presence: true
+  validates :start_at, presence: true
+  validates :end_at, presence: true
+  validate :start_at_should_be_before_end_at
+
+  private
+
+  def start_at_should_be_before_end_at
+    return unless start_at && end_at
+
+    if start_at >= end_at
+      errors.add(:start_at, "は終了時間よりも前に設定してください")
+    end
+  end
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,6 +12,8 @@
       .container
         = link_to "AwesomeEvents", root_path, class: "navbar-brand mr-auto"
         %ul.navbar-nav
+          %li.nav-item
+            = link_to "イベントを作る", new_event_path, class: "nav-link"
           - if logged_in?
             %li.nav-item
               = link_to "ログアウト", logout_path, class: "nav-link", method: :delete

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module AwesomeEvents
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
-
+    config.time_zone = "Tokyo"
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :events
   root 'welcome#index'
   get "/auth/:provider/callback" => "sessions#create"
   delete "/logout" => "sessions#destroy"

--- a/db/migrate/20201206010345_create_events.rb
+++ b/db/migrate/20201206010345_create_events.rb
@@ -1,0 +1,16 @@
+class CreateEvents < ActiveRecord::Migration[6.0]
+  def change
+    create_table :events do |t|
+      t.bigint :owner_id
+      t.string :name, null: false
+      t.string :place, null: false
+      t.datetime :start_at, null: false
+      t.datetime :end_at, null: false
+      t.text :content, null: false
+
+      t.timestamps
+    end
+
+    add_index :events, :owner_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_22_005318) do
+ActiveRecord::Schema.define(version: 2020_12_06_010345) do
+
+  create_table "events", force: :cascade do |t|
+    t.bigint "owner_id"
+    t.string "name", null: false
+    t.string "place", null: false
+    t.datetime "start_at", null: false
+    t.datetime "end_at", null: false
+    t.text "content", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["owner_id"], name: "index_events_on_owner_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "provider", null: false


### PR DESCRIPTION
## 変更内容
- タイムゾーンを東京に設定
- `bin/rails g resource event`を実行
- eventモデルにバリデーションを追加
- `bin/rails db:migrate`を実行
- イベント作成ページへのリンクを追加

## 注意点
- この時点では`events_controller.rb`にアクションの定義は行っていません