### PR TITLE
イベント作成時にバリデーションのエラーメッセージが表示されるように修正

### DIFF
--- a/app/views/application/_errors.html.haml
+++ b/app/views/application/_errors.html.haml
@@ -1,0 +1,4 @@
+.alert.alert-danger
+  %ul.mb-0
+    - errors.full_messages.each do |message|
+      %li= message

--- a/app/views/events/create.js.erb
+++ b/app/views/events/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById("errors").innerHTML = "<%= j render("errors", errors: @event.errors) %>"


### PR DESCRIPTION
## 目的
- イベント作成に失敗した際、エラーメッセージを表示させたい

## やったこと
- イベント作成画面にバリデーションのエラーメッセージが表示されるようにした

## やっていないこと
- エラーメッセージの日本語化