### PR TITLE
i18nを導入し、default_localを':ja'に設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,3 +56,4 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'hamlit-rails', '~> 0.2.3'
+gem 'rails-i18n', '~> 6.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.3)
       actionpack (= 6.0.3)
       activesupport (= 6.0.3)
@@ -275,6 +278,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection (~> 0.1.2)
   puma (~> 4.1)
   rails (~> 6.0.3)
+  rails-i18n (~> 6.0.0)
   sass-rails (>= 6)
   selenium-webdriver
   spring

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,7 @@ module AwesomeEvents
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
     config.time_zone = "Tokyo"
+    config.i18n.default_locale = :ja
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,11 @@
+ja:
+  activerecord:
+    models:
+      event: イベント
+    attributes:
+      event:
+        name: 名前
+        place: 場所
+        start_at: 開始時間
+        end_at: 終了時間
+        content: 内容


### PR DESCRIPTION
## 目的
locale対応をしていなかったため、i18nを導入し日本語に対応させる。

## 変更点
- rails-i18nをインストール
- default_localeを':ja'に設定
- 日本語のlocaleファイルを作成
