### PR TITLE
イベント削除機能を追加

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -28,6 +28,12 @@ class EventsController < ApplicationController
     end
   end
 
+  def destroy
+    @event = current_user.created_events.find(params[:id])
+    @event.destroy!
+    redirect_to root_path, notice: "削除しました"
+  end
+
   private
 
   def event_params

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -22,3 +22,4 @@
   .col-4
     - if @event.created_by?(current_user)
       = link_to "イベントを編集する", edit_event_path(@event), class: "btn btn-info btn-lg btn-block"
+      = link_to "イベントを削除する", event_path(@event), class: "btn btn-danger btn-lg btn-block", method: :delete, data: { confirm: "本当に削除しますか？" }


### PR DESCRIPTION
## 目的

イベントの削除をできるようにする

## やったこと

- イベントの詳細ページにイベント削除のリンクを追加
  - 削除前には確認のダイアログを表示する