### PR TITLE
イベント新規作成ページの表示を確認するテストを追加

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -6,4 +6,5 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   else
     driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
   end
+  include SignInHelper
 end

--- a/test/sign_in_helper.rb
+++ b/test/sign_in_helper.rb
@@ -1,0 +1,18 @@
+module SignInHelper
+  def sign_in_as(user)
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.add_mock(
+      user.provider,
+      uid: user.uid,
+      info: { nickname: user.name,
+              image: user.image_url })
+
+    visit root_url
+    click_on "GitHubでログイン"
+    @current_user = user
+  end
+
+  def current_user
+    @current_user
+  end
+end

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -6,4 +6,11 @@ class EventsTest < ApplicationSystemTestCase
     visit event_url(event)
     assert_selector "h1", text: event.name
   end
+
+  test "/events/new ページを表示" do
+    sign_in_as(FactoryBot.create(:user))
+
+    visit new_event_url
+    assert_selector "h1", text: "イベント作成"
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
+require_relative 'sign_in_helper'
 require 'rails/test_help'
 
 class ActiveSupport::TestCase


### PR DESCRIPTION
## やったこと

- SignInヘルパーを作成
    - GitHub認証をモック化
- イベント新規作成ページの表示を確認するテストを追加
