### PR TITLE
ユーザーによってイベントの削除の可否を確認するテストを追加

### DIFF
--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class EventsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -9,4 +9,16 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
       delete event_url(event)
     end
   end
+
+  test "他の人が作ったイベントは削除できない" do
+    event_owner = FactoryBot.create(:user)
+    event = FactoryBot.create(:event, owner: event_owner)
+    sign_in_user = FactoryBot.create(:user)
+    sign_in_as sign_in_user
+    assert_difference("Event.count", 0) do
+      assert_raises(ActiveRecord::RecordNotFound) do
+        delete event_url(event)
+      end
+    end
+  end
 end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1,7 +1,12 @@
 require 'test_helper'
 
 class EventsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test "自分が作ったイベントは削除できる" do
+    event_owner = FactoryBot.create(:user)
+    event = FactoryBot.create(:event, owner: event_owner)
+    sign_in_as event_owner
+    assert_difference("Event.count", -1) do
+      delete event_url(event)
+    end
+  end
 end

--- a/test/sign_in_helper.rb
+++ b/test/sign_in_helper.rb
@@ -7,12 +7,24 @@ module SignInHelper
       info: { nickname: user.name,
               image: user.image_url })
 
-    visit root_url
-    click_on "GitHubでログイン"
+    case
+    when respond_to?(:visit)
+      visit root_url
+      click_on "GitHubでログイン"
+    when respond_to?(:get)
+      get "/auth/github/callback"
+    else
+      raise NotImplementedError.new
+    end
+
     @current_user = user
   end
 
   def current_user
     @current_user
   end
+end
+
+class ActionDispatch::IntegrationTest
+  include SignInHelper
 end


### PR DESCRIPTION
## 目的

イベント削除の権限を確認するテストを追加する

## やったこと

### イベント削除の権限を確認するテストを追加

テストケース

- イベントのオーナーによる削除
- イベントのオーナー以外による削除

### その他

- sign_in_helper を機能テストでも利用できるように修正