### PR TITLE
イベントのファイルアップロード機能を追加

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -40,7 +40,7 @@ class EventsController < ApplicationController
 
   def event_params
     params.require(:event).permit(
-      :name, :place, :content, :start_at, :end_at
+      :name, :place, :image, :remove_image, :content, :start_at, :end_at
     )
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,5 @@
 class Event < ApplicationRecord
+  has_one_attached :image
   has_many :tickets, dependent: :destroy
   belongs_to :owner, class_name: "User"
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,5 @@
 class Event < ApplicationRecord
-  has_one_attached :image
+  has_one_attached :image, dependent: false
   has_many :tickets, dependent: :destroy
   belongs_to :owner, class_name: "User"
 
@@ -9,6 +9,10 @@ class Event < ApplicationRecord
   validates :start_at, presence: true
   validates :end_at, presence: true
   validate :start_at_should_be_before_end_at
+
+  attr_accessor :remove_image
+
+  before_save :remove_image_if_user_accept
 
   def created_by?(user)
     return false unless user
@@ -23,5 +27,9 @@ class Event < ApplicationRecord
     if start_at >= end_at
       errors.add(:start_at, "は終了時間よりも前に設定してください")
     end
+  end
+  
+  def remove_image_if_user_accept
+    self.image = nil if ActiveRecord::Type::Boolean.new.cast(remove_image)
   end
 end

--- a/app/views/events/edit.html.haml
+++ b/app/views/events/edit.html.haml
@@ -21,4 +21,15 @@
   .form-group
     = f.label :content
     = f.text_area :content, class: "form-control", row: 10
+  .form-group
+    = f.label :image
+    - if @event.image.attached?
+      = image_tag @event.image,
+          class: "img-thumbnail d-block mb-3", width: 200, height: 200
+    = f.file_field :image, class: "form-control-file"
+  - if @event.image.attached?
+    .checkbox
+      %label
+        = f.check_box :remove_image
+        画像を削除する
   = f.submit class: "btn btn-primary"

--- a/app/views/events/new.html.haml
+++ b/app/views/events/new.html.haml
@@ -21,4 +21,7 @@
   .form-group
     = f.label :content
     = f.text_area :content, class: "form-control", row: 10
+  .form-group
+    = f.label :image
+    = f.file_field :image, class: "form-control-file"
   = f.submit class: "btn btn-primary"

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -2,6 +2,9 @@
 .row
   .col-8
     .card.mb-2
+      - if @event.image.attached?
+        = image_tag @event.image, class: "card-img-top"
+    .card.mb-2
       %h5.card-header イベント内容
       .card-body
         %p.card-text= @event.content

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,5 +10,6 @@ ja:
         start_at: 開始時間
         end_at: 終了時間
         content: 内容
+        image: 画像
       ticket:
         comment: コメント

--- a/db/migrate/20210220235152_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210220235152_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_27_000737) do
+ActiveRecord::Schema.define(version: 2021_02_20_235152) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "events", force: :cascade do |t|
     t.bigint "owner_id"
@@ -44,5 +65,6 @@ ActiveRecord::Schema.define(version: 2020_12_27_000737) do
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "tickets", "events"
 end


### PR DESCRIPTION
## やったこと
- イベントに画像ファイルを登録できるようにした
- イベントの情報編集時にイベントと画像の関連付けを削除できるようにした
  - イベントを削除する際、ActiveStorage::Attachedを削除し、ActiveStorage::Blobと画像やサムネイルは残すようにしています
- イベントに登録した画像を閲覧できるようにした