### PR TITLE
Add file content type validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'jbuilder', '~> 2.7'
 
 # Use Active Storage variant
 gem 'image_processing', '~> 1.2'
+gem 'active_storage_validations', '~> 0.8.8'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_storage_validations (0.8.9)
+      rails (>= 5.2.0)
     activejob (6.0.3)
       activesupport (= 6.0.3)
       globalid (>= 0.3.6)
@@ -280,6 +282,7 @@ PLATFORMS
   x86-mswin32
 
 DEPENDENCIES
+  active_storage_validations (~> 0.8.8)
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
@@ -309,4 +312,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.2.0.rc.2
+   2.2.8

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,6 +3,7 @@ class Event < ApplicationRecord
   has_many :tickets, dependent: :destroy
   belongs_to :owner, class_name: "User"
 
+  validates :image, content_type: %i[png jpg jpeg]
   validates :name, length: { maximum: 50 }, presence: true
   validates :place, length: { maximum: 100 }, presence: true
   validates :content, length: { maximum: 2000 }, presence: true
@@ -28,7 +29,7 @@ class Event < ApplicationRecord
       errors.add(:start_at, "は終了時間よりも前に設定してください")
     end
   end
-  
+
   def remove_image_if_user_accept
     self.image = nil if ActiveRecord::Type::Boolean.new.cast(remove_image)
   end

--- a/app/views/events/edit.html.haml
+++ b/app/views/events/edit.html.haml
@@ -26,7 +26,7 @@
     - if @event.image.attached? && @event.image.blob&.persisted?
       = image_tag(@event.image.variant(resize_to_fit: [200, 200]), class: "img-thumbnail d-block mb-3")
     = f.file_field :image, class: "form-control-file"
-  - if @event.image.attached?
+  - if @event.image.attached? && @event.image.blob&.persisted?
     .checkbox
       %label
         = f.check_box :remove_image


### PR DESCRIPTION
## やったこと

- Event の image に content-type でのバリデーションを追加
- event の編集画面で「画像を削除する」のチェックボックスの表示条件を修正
  - 画像がアップロード済の場合のみ表示する
  - img タグはあっても画像がない、という状況が発生するのを防ぐため