### PR TITLE
イベントの画像の最大容量と縦幅横幅に対するバリデーションを追加

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,7 +3,9 @@ class Event < ApplicationRecord
   has_many :tickets, dependent: :destroy
   belongs_to :owner, class_name: "User"
 
-  validates :image, content_type: %i[png jpg jpeg]
+  validates :image,
+            content_type: %i[png jpg jpeg],
+            size: { less_than_or_equal_to: 10.megabytes }
   validates :name, length: { maximum: 50 }, presence: true
   validates :place, length: { maximum: 100 }, presence: true
   validates :content, length: { maximum: 2000 }, presence: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,7 +5,8 @@ class Event < ApplicationRecord
 
   validates :image,
             content_type: %i[png jpg jpeg],
-            size: { less_than_or_equal_to: 10.megabytes }
+            size: { less_than_or_equal_to: 10.megabytes },
+            dimension: { width: { max: 2000}, height: { max: 2000 } }
   validates :name, length: { maximum: 50 }, presence: true
   validates :place, length: { maximum: 100 }, presence: true
   validates :content, length: { maximum: 2000 }, presence: true


### PR DESCRIPTION
### やったこと
- イベントの作成・編集時に10MB以上の画像ファイルが指定された場合、バリデーションエラーになるようにした
- イベントの作成・編集時に縦幅または横幅が2000px以上の画像ファイルが指定された場合、バリデーションエラーになるようにした

### やっていないこと
- ダイレクトアップロードの実装
  - 書籍の内容には含まれているが、実際にS3へのダイレクトアップロードはしないため