### PR TITLE
イベント一覧に検索機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'omniauth-github', '~> 1.4.0'
 gem 'omniauth-rails_csrf_protection', '~> 0.1.2'
 
 gem 'kaminari', '~> 1.2.0'
+gem 'searchkick', '~> 4.3.0'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,14 @@ GEM
     childprocess (3.0.0)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    elasticsearch (7.11.2)
+      elasticsearch-api (= 7.11.2)
+      elasticsearch-transport (= 7.11.2)
+    elasticsearch-api (7.11.2)
+      multi_json
+    elasticsearch-transport (7.11.2)
+      faraday (~> 1)
+      multi_json
     erubi (1.10.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
@@ -237,6 +245,10 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    searchkick (4.3.1)
+      activemodel (>= 5)
+      elasticsearch (>= 6)
+      hashie
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -311,6 +323,7 @@ DEPENDENCIES
   rails (~> 6.0.3)
   rails-i18n (~> 6.0.0)
   sass-rails (>= 6)
+  searchkick (~> 4.3.0)
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/README.md
+++ b/README.md
@@ -8,3 +8,17 @@
 $ brew install vips
 $ bin/setup
 ```
+
+### Elasticsearchのインストール
+
+```
+$ brew tap elastic/tap
+$ brew install elastic/tap/elasticsearch-full
+$ elasticsearch-plugin install analysis-kuromoji
+```
+
+### Elasticsearchの起動
+```
+$ elasticsearch
+$ bin/rails r Event.reindex
+```

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -2,7 +2,13 @@ class WelcomeController < ApplicationController
   skip_before_action :authenticate
 
   def index
-    @events = Event.page(params[:page]).per(10).
-    where("start_at > ?", Time.zone.now).order(:start_at)
+    @event_search_form = EventSearchForm.new(event_search_form_params)
+    @events = @event_search_form.search
+  end
+
+  private
+
+  def event_search_form_params
+    params.fetch(:event_search_form, {}).permit(:keyword, :start_at).merge(page: params[:page])
   end
 end

--- a/app/forms/event_search_form.rb
+++ b/app/forms/event_search_form.rb
@@ -1,0 +1,30 @@
+class EventSearchForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :keyword, :string
+  attribute :page, :integer
+
+  def search
+    Event.search(
+      keyword_for_search,
+      where: { start_at: { gt: start_at }},
+      page: page,
+      per_page: 10
+    )
+  end
+
+  def start_at
+    @start_at || Time.current
+  end
+
+  def start_at=(new_start_at)
+    @start_at = new_start_at.in_time_zone
+  end
+
+  private
+
+  def keyword_for_search
+    keyword.presence || "*"
+  end
+end

--- a/app/javascript/get_form_turbolinks.js
+++ b/app/javascript/get_form_turbolinks.js
@@ -1,0 +1,11 @@
+import Turbolinks from "turbolinks"
+
+document.addEventListener("turbolinks:load", function(event) {
+  const forms = document.querySelectorAll("form[method=get][data-remote=true]")
+  for (const form of forms) {
+    form.addEventListener("ajax:beforeSend", function({ detail: [, { url }] }) {
+      Turbolinks.visit(url)
+      event.preventDefault()
+    })
+  }
+})

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,6 +6,7 @@
 require("@rails/ujs").start()
 require("turbolinks").start()
 require("@rails/activestorage").start()
+require("get_form_turbolinks")
 
 import "bootstrap"
 import "bootstrap/scss/bootstrap.scss"

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ApplicationRecord
+  searchkick language: "japanese"
+
   has_one_attached :image, dependent: false
   has_many :tickets, dependent: :destroy
   belongs_to :owner, class_name: "User"
@@ -21,6 +23,16 @@ class Event < ApplicationRecord
   def created_by?(user)
     return false unless user
     owner_id == user.id
+  end
+
+  def search_data
+    {
+        name: name,
+        place: place,
+        content: content,
+        owner_name: owner&.name,
+        start_at: start_at
+    }
   end
 
   private

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -1,5 +1,15 @@
 %h1 イベント一覧
 
+= form_with(model: @event_search_form, url: root_path, method: :get) do |f|
+  .form_group
+    = f.label :keyword, "キーワード"
+    = f.text_field :keyword, class: "form-control"
+  .form_group
+    = f.label :start_at, "以降に開催されるイベント"
+    = f.datetime_field :start_at, class: "form-control"
+  .form_group
+    = f.submit "検索", class: "btn btn-primary"
+
 %ul.list-group.mb-3
   - @events.each do |event|
     = link_to(event, class: "list-group-item list-group-item-action") do


### PR DESCRIPTION
### やったこと
イベント一覧に検索機能を追加
  - [x]  Elasticsearchを導入
  - [x] 検索フォームをイベント一覧に追加 
  - [x] 検索リクエストをTurbolinks環境でリンクをクリックしたのと同じ挙動にする
  - [x] イベント検索用のフォームオブジェクトの追加
  - [x] welcomeコントローラーのindexアクションでイベント検索用のフォームオブジェクトを使用するようにした