### PR TITLE
Fix errors on bundle install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-
+source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.6.6'


### PR DESCRIPTION
以下のエラーを修正しました。

```
Your Gemfile has no gem server sources. If you need gems that are not
already on your machine, add a line like this to your Gemfile:
source 'https://rubygems.org'
Could not find gem 'tzinfo-data' in locally installed gems.
The source does not contain any versions of 'tzinfo-data'
```
