### PR TITLE
GitHub Actions実行時に発生したエラーを解消

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Build and test
         env:
           RAILS_ENV: test
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
         run: |
           sudo apt-get -yqq install libsqlite3-dev
           bundle install --jobs 4 --retry 3


### PR DESCRIPTION
master.keyの情報がなくエラーが発生していたため、master.keyに出力する処理をGitHub Actionsの設定ファイルに追加した。

cf.
https://github.com/fjordllc/awesome_events/actions/runs/910649791