### PR TITLE
「他の人が作ったイベントは削除できない」のテストが落ちる修正

### DIFF
--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -16,9 +16,8 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     sign_in_user = FactoryBot.create(:user)
     sign_in_as sign_in_user
     assert_difference("Event.count", 0) do
-      assert_raises(ActiveRecord::RecordNotFound) do
-        delete event_url(event)
-      end
+      delete event_url(event)
     end
+    assert_response(:missing)
   end
 end


### PR DESCRIPTION
## 背景
`test/controllers/events_controller_test.rb`のassert_raises(ActiveRecord::RecordNotFound)箇所で、「ActiveRecord::RecordNotFound expected but nothing was raised.」のエラーでテストが落ちていた。

## 原因
https://github.com/fjordllc/awesome_events/pull/37 4b3d342 にて、
application_contorollerでActiveRecord::RecordNotFoundの例外をrescueし、404ページ(app/views/application/error404.html.haml)に飛ばすようにしたため。

## やったこと
- `test/controllers/events_controller_test.rb`の修正
  - assert_raises(ActiveRecord::RecordNotFound)を削除
  - assert_response(:missing)で404が表示されることを確認するテストを追加