### PR TITLE
GemfileにBrakemanを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development do
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
+  gem 'brakeman'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       msgpack (~> 1.0)
     bootsnap (1.5.1-java)
       msgpack (~> 1.0)
+    brakeman (5.0.4)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.33.0)
@@ -336,6 +337,7 @@ PLATFORMS
 DEPENDENCIES
   active_storage_validations (~> 0.8.8)
   bootsnap (>= 1.4.2)
+  brakeman
   byebug
   capybara (>= 2.15)
   factory_bot_rails


### PR DESCRIPTION
## やったこと
脆弱性を静的解析するためにBrakemanのgemを追加
ローカル環境でオプションなしでbrakemanコマンドを実行した結果、問題は出力されませんでした。

実行ログ
```
$ bundle exec brakeman

== Overview ==

Controllers: 7
Models: 4
Templates: 21
Errors: 0
Security Warnings: 0

== Warning Types ==


No warnings found
```