### PR TITLE
rack-mini-profilerを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :development do
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'brakeman'
+  gem 'rack-mini-profiler', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,8 @@ GEM
     racc (1.5.2)
     racc (1.5.2-java)
     rack (2.2.3)
+    rack-mini-profiler (2.3.2)
+      rack (>= 1.2.0)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -357,6 +359,7 @@ DEPENDENCIES
   omniauth-github (~> 1.4.0)
   omniauth-rails_csrf_protection (~> 0.1.2)
   puma (~> 4.1)
+  rack-mini-profiler
   rails (~> 6.0.3.6)
   rails-i18n (~> 6.0.0)
   rubocop
@@ -379,4 +382,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.2.8
+   2.2.19


### PR DESCRIPTION
## やったこと
ローカルでパフォーマンス測定をするために、`rack-mini-profiler`gemを追加した。

[MiniProfiler/rack\-mini\-profiler: Profiler for your development and production Ruby rack apps\.](https://github.com/MiniProfiler/rack-mini-profiler)